### PR TITLE
Twitterの埋め込みに対応

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -46,6 +46,6 @@ class ArticlesController < ApplicationController
   private
 
   def article_params
-    params.require(:article).permit(:title, :body, :status, :youtube_url)
+    params.require(:article).permit(:title, :body, :status, :embed_type, :embed_url)
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,14 +3,25 @@ class Article < ApplicationRecord
 
   has_many :comments, dependent: :destroy
 
+  EMBED_TYPES = ['youtube', 'twitter']
+
   validates :title, presence: true
   validates :body, presence: true, length: { minimum: 10 }
-  validates :youtube_url, format: { with: /\A(https?\:\/\/)?(www\.youtube\.com|youtu\.?be)\/.+\z/, message: "有効なYouTube URLではありません" }, allow_blank: true
+  validates :embed_type, inclusion: { in: EMBED_TYPES }, allow_nil: true
+  validate :embed_url_format
+
   after_initialize :set_default_status, if: :new_record?
 
   def youtube_id
-    if youtube_url.present?
-      extract_youtube_id(youtube_url)
+    extract_youtube_id(embed_url) if embed_type == 'youtube'
+  end
+
+  def embed_content
+    case embed_type
+    when 'youtube'
+      youtube_embed
+    when 'twitter'
+      twitter_embed
     end
   end
 
@@ -20,7 +31,28 @@ class Article < ApplicationRecord
     self.status ||= 'public'
   end
 
+  def youtube_embed
+    "<iframe width='560' height='315' src='https://www.youtube.com/embed/#{youtube_id}' frameborder='0' allowfullscreen></iframe>" if youtube_id
+  end
+
+  def twitter_embed
+    "<blockquote class='twitter-tweet'><a href='#{embed_url}'></a></blockquote><script async src='https://platform.twitter.com/widgets.js' charset='utf-8'></script>" if embed_url
+  end
+
   def extract_youtube_id(url)
-    url[/(?<=v=)[\w-]+/] || url[/(?<=youtu.be\/)[\w-]+/]
+    url[/(?<=v=)[\w-]+/] || url[/(?<=youtu.be\/)[\w-]+/] if url
+  end
+
+  def embed_url_format
+    case embed_type
+    when 'youtube'
+      unless embed_url =~ /\A(https?\:\/\/)?(www\.youtube\.com|youtu\.?be)\/.+\z/
+        errors.add(:embed_url, "有効なYouTube URLではありません")
+      end
+    when 'twitter'
+      unless embed_url =~ /\Ahttps?:\/\/twitter\.com\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)\z/
+        errors.add(:embed_url, "有効なTwitter URLではありません")
+      end
+    end
   end
 end

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -1,31 +1,41 @@
 <%= form_with model: article do |form| %>
+  <% if article.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(article.errors.count, "error") %> prohibited this article from being saved:</h2>
+      <ul>
+        <% article.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
   <div>
     <%= form.label :title %><br>
-    <%= form.text_field :title %>
-    <% article.errors.full_messages_for(:title).each do |message| %>
-      <div><%= message %></div>
-    <% end %>
+    <%= form.text_field :title %><br>
   </div>
 
   <div>
     <%= form.label :body %><br>
     <%= form.text_area :body %><br>
-    <% article.errors.full_messages_for(:body).each do |message| %>
-      <div><%= message %></div>
-    <% end %>
-  </div>
-
-  <div>
-    <%= form.label :youtube_url, "YouTube動画のURL" %><br>
-    <%= form.text_field :youtube_url %><br>
   </div>
 
   <div>
     <%= form.label :status %><br>
-    <%= form.select :status, Visible::VALID_STATUSES, selected: article.status || 'public' %>
+    <%= form.select :status, ['public', 'private', 'archived'], selected: 'public' %><br>
   </div>
 
   <div>
-    <%= form.submit %>
+    <%= form.label :embed_type, "埋め込みタイプ" %><br>
+    <%= form.select :embed_type, Article::EMBED_TYPES, include_blank: '選択してください' %><br>
+  </div>
+
+  <div>
+    <%= form.label :embed_url, "埋め込みURL" %><br>
+    <%= form.text_field :embed_url %><br>
+  </div>
+
+  <div>
+    <%= form.submit %><br>
   </div>
 <% end %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -2,9 +2,9 @@
 
 <p><%= @article.body %></p>
 
-<% if @article.youtube_id.present? %>
-  <h2>動画</h2>
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/<%= @article.youtube_id %>" frameborder="0" allowfullscreen></iframe>
+<% if @article.embed_content.present? %>
+  <h2>埋め込みコンテンツ</h2>
+  <%= @article.embed_content.html_safe %>
 <% end %>
 
 <ul>

--- a/db/migrate/20240716114013_add_embed_type_to_articles.rb
+++ b/db/migrate/20240716114013_add_embed_type_to_articles.rb
@@ -1,0 +1,6 @@
+class AddEmbedTypeToArticles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :articles, :embed_type, :string
+    rename_column :articles, :youtube_url, :embed_url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_15_052124) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_16_114013) do
   create_table "articles", charset: "utf8mb4", force: :cascade do |t|
     t.string "title"
     t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "status"
-    t.string "youtube_url"
+    t.string "embed_url"
+    t.string "embed_type"
   end
 
   create_table "comments", charset: "utf8mb4", force: :cascade do |t|


### PR DESCRIPTION
モデルの修正 (app/models/article.rb):

EMBED_TYPES 定数の追加 (YouTube と Twitter)
embed_type と embed_url のバリデーション追加
youtube_id, embed_content メソッドの実装
embed_url_format バリデーションメソッドの実装


マイグレーションの作成と実行:

rails generate migration AddEmbedTypeToArticles embed_type:string
マイグレーションファイルの編集 (youtube_url を embed_url にリネーム)
rails db:migrate の実行


コントローラーの修正 (app/controllers/articles_controller.rb):

article_params メソッドに embed_type と embed_url を追加


ビューの修正:
a. フォーム (app/views/articles/_form.html.erb):

embed_type 選択フィールドの追加
embed_url 入力フィールドの追加

b. 記事表示 (app/views/articles/show.html.erb):

embed_content の表示部分を追加